### PR TITLE
新增測試檔案以驗證活動報名及取消功能

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "python.testing.pytestArgs": [
+        "tests"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 httpx
 watchfiles
+pytest

--- a/tests/backend/conftest.py
+++ b/tests/backend/conftest.py
@@ -1,0 +1,21 @@
+from copy import deepcopy
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src import app as app_module
+
+
+@pytest.fixture(autouse=True)
+def restore_activities():
+    original_activities = deepcopy(app_module.activities)
+
+    yield
+
+    app_module.activities.clear()
+    app_module.activities.update(original_activities)
+
+
+@pytest.fixture
+def client():
+    return TestClient(app_module.app)

--- a/tests/backend/test_activities.py
+++ b/tests/backend/test_activities.py
@@ -1,0 +1,25 @@
+from src import app as app_module
+
+
+def test_root_redirects_to_static_index(client):
+    # Arrange
+    expected_location = "/static/index.html"
+
+    # Act
+    response = client.get("/", follow_redirects=False)
+
+    # Assert
+    assert response.status_code == 307
+    assert response.headers["location"] == expected_location
+
+
+def test_get_activities_returns_current_activity_catalog(client):
+    # Arrange
+    expected_activities = app_module.activities
+
+    # Act
+    response = client.get("/activities")
+
+    # Assert
+    assert response.status_code == 200
+    assert response.json() == expected_activities

--- a/tests/backend/test_signup.py
+++ b/tests/backend/test_signup.py
@@ -1,0 +1,104 @@
+from src import app as app_module
+
+
+def test_signup_adds_new_student_to_activity(client):
+    # Arrange
+    activity_name = "Chess Club"
+    email = "newstudent@mergington.edu"
+
+    # Act
+    response = client.post(
+        f"/activities/{activity_name}/signup",
+        params={"email": email},
+    )
+
+    # Assert
+    assert response.status_code == 200
+    assert response.json() == {
+        "message": f"Signed up {email} for {activity_name}"
+    }
+    assert email in app_module.activities[activity_name]["participants"]
+
+
+def test_signup_rejects_duplicate_student_for_activity(client):
+    # Arrange
+    activity_name = "Chess Club"
+    email = "michael@mergington.edu"
+
+    # Act
+    response = client.post(
+        f"/activities/{activity_name}/signup",
+        params={"email": email},
+    )
+
+    # Assert
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Student is already signed up"}
+    assert app_module.activities[activity_name]["participants"].count(email) == 1
+
+
+def test_signup_rejects_unknown_activity(client):
+    # Arrange
+    activity_name = "Robotics Club"
+    email = "newstudent@mergington.edu"
+
+    # Act
+    response = client.post(
+        f"/activities/{activity_name}/signup",
+        params={"email": email},
+    )
+
+    # Assert
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Activity not found"}
+
+
+def test_unregister_removes_student_from_activity(client):
+    # Arrange
+    activity_name = "Chess Club"
+    email = "michael@mergington.edu"
+
+    # Act
+    response = client.delete(
+        f"/activities/{activity_name}/signup",
+        params={"email": email},
+    )
+
+    # Assert
+    assert response.status_code == 200
+    assert response.json() == {
+        "message": f"Unregistered {email} from {activity_name}"
+    }
+    assert email not in app_module.activities[activity_name]["participants"]
+
+
+def test_unregister_rejects_student_not_signed_up(client):
+    # Arrange
+    activity_name = "Chess Club"
+    email = "not-enrolled@mergington.edu"
+
+    # Act
+    response = client.delete(
+        f"/activities/{activity_name}/signup",
+        params={"email": email},
+    )
+
+    # Assert
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Student is not signed up for this activity"}
+
+
+def test_unregister_rejects_unknown_activity(client):
+    # Arrange
+    activity_name = "Robotics Club"
+    email = "student@mergington.edu"
+
+    # Act
+    response = client.delete(
+        f"/activities/{activity_name}/signup",
+        params={"email": email},
+    )
+
+    # Assert
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Activity not found"}


### PR DESCRIPTION
This pull request introduces a comprehensive test suite for the backend API, ensuring correct behavior for activity signup and unregistration endpoints, as well as basic routing. It also configures the development environment for running tests with pytest and provides fixtures to maintain test isolation.

**Testing infrastructure improvements:**

* Added `.vscode/settings.json` to configure pytest as the test runner for Python development, disabling unittest and setting the test directory to `tests`.
* Introduced `conftest.py` with fixtures for a FastAPI test client and automatic restoration of the `activities` data after each test, ensuring tests do not interfere with each other.

**API endpoint test coverage:**

* Added `test_activities.py` to verify root URL redirection and that the `/activities` endpoint returns the current activity catalog.
* Added `test_signup.py` to test signup and unregistration logic, including handling of duplicate signups, unknown activities, and correct participant management for activities.